### PR TITLE
Prj 467 organize creation

### DIFF
--- a/src/main/java/ar/com/kfgodel/nary/api/Nary.java
+++ b/src/main/java/ar/com/kfgodel/nary/api/Nary.java
@@ -11,6 +11,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Enumeration;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Spliterator;
 import java.util.Spliterators;
@@ -207,5 +208,15 @@ public interface Nary<T> extends MonoElement<T>, MultiElement<T> {
     return Nary.from(spliterator);
   }
 
+  /**
+   * Creates a nary from the pairs of elements in a {@link Map}
+   * @param map The map whose pairs of elements can be iterated
+   * @param <K> The type of Keys
+   * @param <V> The type of values
+   * @return The created Nary with the entries of the map
+   */
+  static <K,V> Nary<Map.Entry<K,V>> from(Map<K,V> map){
+    return Nary.from(map.entrySet().stream());
+  }
 
 }

--- a/src/main/java/ar/com/kfgodel/nary/api/Nary.java
+++ b/src/main/java/ar/com/kfgodel/nary/api/Nary.java
@@ -61,66 +61,6 @@ public interface Nary<T> extends MonoElement<T>, MultiElement<T> {
 
 
   /**
-   * Creates a nary enumerating its elements
-   *
-   * @param element     The first mandatory element
-   * @param additionals The optional extra elements
-   * @param <T>         The type of expected nary content
-   * @return The created nary
-   */
-  static <T> Nary<T> of(T element, T... additionals){
-    Nary<T> elementNary = OneElementNary.create(element);
-    if (additionals == null || additionals.length == 0) {
-      // It's only one element
-      return elementNary;
-    }
-    Nary<T> additionalsNary = Nary.create(additionals);
-    return elementNary.concat(additionalsNary);
-  }
-
-  /**
-   * Creates a nary from a native stream. The operation on this nary will consume the stream
-   * @param stream original stream
-   * @param <T> Expected type
-   * @return A nre nary
-   */
-  static<T> Nary<T> create(Stream<? extends T> stream){
-    if(stream instanceof Nary){
-      //To avoid unnecesary wrapping
-      return (Nary<T>) stream;
-    }
-    return StreamBasedNary.create(stream);
-  }
-
-  /**
-   * Creates a nary from a native optional. Stream like operations will generate a stream from the
-   * optional
-   * @param nativeOptional original optional
-   * @param <T> The expected element type
-   * @return A new nary
-   */
-  static<T> Nary<T> create(Optional<? extends T> nativeOptional){
-    if(nativeOptional.isPresent()){
-      return OneElementNary.create(nativeOptional.get());
-    }
-    return empty();
-  }
-
-  /**
-   * Creates a nary from an element whose absence is represented by null
-   * @param nullableElement An unknown value
-   * @param <T> The expected element type
-   * @return The created nary
-   */
-  static<T> Nary<T> ofNullable(T nullableElement){
-    if(nullableElement == null){
-      return Nary.empty();
-    }else{
-      return Nary.of(nullableElement);
-    }
-  }
-
-  /**
    * Creates an empty nary to represent an empty set
    * @param <T> Expected type
    * @return The empty instance
@@ -130,13 +70,84 @@ public interface Nary<T> extends MonoElement<T>, MultiElement<T> {
   }
 
   /**
+   * Creates a nary from a native stream. The operation on this nary will consume the stream
+   * @param stream original stream
+   * @param <T> Expected type
+   * @return A nre nary
+   */
+  static<T> Nary<T> from(Stream<? extends T> stream){
+    if(stream instanceof Nary){
+      //To avoid unnecesary wrapping
+      return (Nary<T>) stream;
+    }
+    return StreamBasedNary.create(stream);
+  }
+
+  /**
+   * Creates a nary with a single element.<br>
+   *
+   * @param element     The non null element
+   * @param <T>         The type of expected nary content
+   * @return The non empty created nary
+   */
+  static <T> Nary<T> ofNonNullable(T element){
+    return OneElementNary.create(element);
+  }
+
+  /**
+   * Creates a nary enumerating its elements.<br>
+   *
+   * @param element     The first mandatory element
+   * @param additionals The optional extra elements
+   * @param <T>         The type of expected nary content
+   * @return The created nary
+   */
+  static <T> Nary<T> ofNonNullable(T element, T... additionals){
+    Nary<T> elementNary = Nary.ofNonNullable(element);
+    if (additionals == null || additionals.length == 0) {
+      // It's only one element
+      return elementNary;
+    }
+    Nary<T> additionalsNary = Nary.from(additionals);
+    return elementNary.concat(additionalsNary);
+  }
+
+  /**
+   * Creates a nary from an element whose absence is represented by null
+   * @param nullableElement An unknown value
+   * @param <T> The expected element type
+   * @return A nary with the given element or empty if it was null
+   */
+  static<T> Nary<T> ofNullable(T nullableElement){
+    if(nullableElement == null){
+      return Nary.empty();
+    }else{
+      return Nary.ofNonNullable(nullableElement);
+    }
+  }
+
+  /**
+   * Creates a nary from a native optional. Stream like operations will generate a stream from the
+   * optional
+   * @param nativeOptional original optional
+   * @param <T> The expected element type
+   * @return A new nary
+   */
+  static<T> Nary<T> from(Optional<? extends T> nativeOptional){
+    return nativeOptional
+      .<Nary<T>>map(Nary::ofNonNullable)
+      .orElseGet(Nary::empty);
+  }
+
+  /**
    * Creates a nary from a spliterator as source for a stream
    * @param spliterator A spliterator
    * @param <T> The expected iterated element types
    * @return The new nary
    */
-  static<T> Nary<T> create(Spliterator<T> spliterator){
-    return Nary.create(StreamSupport.stream(spliterator, false));
+  static<T> Nary<T> from(Spliterator<T> spliterator){
+    final Stream<T> stream = StreamSupport.stream(spliterator, false);
+    return Nary.from(stream);
   }
 
   /**
@@ -145,8 +156,9 @@ public interface Nary<T> extends MonoElement<T>, MultiElement<T> {
    * @param <T> The expected iterated type
    * @return a new nary
    */
-  static<T> Nary<T> create(Iterator<T> iterator){
-    return Nary.create(Spliterators.spliteratorUnknownSize(iterator, 0));
+  static<T> Nary<T> from(Iterator<T> iterator){
+    final Spliterator<T> spliterator = Spliterators.spliteratorUnknownSize(iterator, 0);
+    return Nary.from(spliterator);
   }
 
   /**
@@ -155,8 +167,9 @@ public interface Nary<T> extends MonoElement<T>, MultiElement<T> {
    * @param <T> The expected iterable type
    * @return a new nary
    */
-  static<T> Nary<T> create(Iterable<T> iterable){
-    return Nary.create(iterable.spliterator());
+  static<T> Nary<T> from(Iterable<T> iterable){
+    final Spliterator<T> spliterator = iterable.spliterator();
+    return Nary.from(spliterator);
   }
 
   /**
@@ -166,8 +179,9 @@ public interface Nary<T> extends MonoElement<T>, MultiElement<T> {
    * @param <T>        Expected type for collection elements
    * @return The new nary
    */
-  static<T> Nary<T> create(Collection<T> collection){
-    return Nary.create(collection.stream());
+  static<T> Nary<T> from(Collection<T> collection){
+    final Stream<T> stream = collection.stream();
+    return Nary.from(stream);
   }
 
   /**
@@ -176,9 +190,9 @@ public interface Nary<T> extends MonoElement<T>, MultiElement<T> {
    * @param <T> The expected array element type
    * @return a new nary
    */
-  static<T> Nary<T> create(T[] array){
+  static<T> Nary<T> from(T[] array){
     Stream<T> asStream = Arrays.stream(array);
-    return Nary.create(asStream);
+    return Nary.from(asStream);
   }
 
   /**
@@ -188,9 +202,9 @@ public interface Nary<T> extends MonoElement<T>, MultiElement<T> {
    * @param <T>         The expected element types
    * @return The new nary
    */
-  static <T> Nary<T> create(Enumeration<T> enumeration) {
+  static <T> Nary<T> from(Enumeration<T> enumeration) {
     EnumerationSpliterator<T> spliterator = EnumerationSpliterator.create(enumeration);
-    return Nary.create(spliterator);
+    return Nary.from(spliterator);
   }
 
 

--- a/src/main/java/ar/com/kfgodel/nary/api/Nary.java
+++ b/src/main/java/ar/com/kfgodel/nary/api/Nary.java
@@ -118,7 +118,7 @@ public interface Nary<T> extends MonoElement<T>, MultiElement<T> {
    * @param <T> The expected element type
    * @return A nary with the given element or empty if it was null
    */
-  static<T> Nary<T> ofNullable(T nullableElement){
+  static<T> Nary<T> of(T nullableElement){
     if(nullableElement == null){
       return Nary.empty();
     }else{

--- a/src/main/java/ar/com/kfgodel/nary/impl/EmptyNary.java
+++ b/src/main/java/ar/com/kfgodel/nary/impl/EmptyNary.java
@@ -96,7 +96,7 @@ public class EmptyNary extends NarySupport<Object> {
   @Override
   public Nary<Object> orElseUse(Supplier<?> mapper) throws MoreThanOneElementException {
     final Object element = mapper.get();
-    return Nary.of(element);
+    return Nary.ofNonNullable(element);
   }
 
   @Override
@@ -231,7 +231,7 @@ public class EmptyNary extends NarySupport<Object> {
   @Override
   public Nary<Object> concat(Stream<?> other) {
     // This is empty. Only the other elements are relevant
-    return Nary.create(other);
+    return Nary.from(other);
   }
 
   @Override

--- a/src/main/java/ar/com/kfgodel/nary/impl/NarySupport.java
+++ b/src/main/java/ar/com/kfgodel/nary/impl/NarySupport.java
@@ -52,12 +52,12 @@ public abstract class NarySupport<T> implements Nary<T> {
 
   @Override
   public Nary<T> concat(Optional<? extends T> other) {
-    return concat(Nary.create(other));
+    return concat(Nary.from(other));
   }
 
   @Override
   public Nary<T> add(T... others) {
-    return concat(Nary.create(others));
+    return concat(Nary.from(others));
   }
 
   @Override
@@ -93,7 +93,7 @@ public abstract class NarySupport<T> implements Nary<T> {
   public <U> Nary<U> flatMapOptional(Function<? super T, java.util.Optional<U>> mapper) throws MoreThanOneElementException {
     return returningNaryDo(
       map(mapper)
-      .flatMap(Nary::create)
+      .flatMap(Nary::from)
     );
   }
 
@@ -411,7 +411,7 @@ public abstract class NarySupport<T> implements Nary<T> {
    * @return The created nary
    */
   protected<R> Nary<R> returningNaryDo(Stream<R> nativeStream) {
-    return Nary.create(nativeStream);
+    return Nary.from(nativeStream);
   }
 
   /**
@@ -420,7 +420,7 @@ public abstract class NarySupport<T> implements Nary<T> {
    * @return The created nary
    */
   protected Nary<T> returningNaryDo(java.util.Optional<T> nativeOptional) {
-    return Nary.create(nativeOptional);
+    return Nary.from(nativeOptional);
   }
 
 }

--- a/src/main/java/ar/com/kfgodel/nary/impl/OneElementNary.java
+++ b/src/main/java/ar/com/kfgodel/nary/impl/OneElementNary.java
@@ -50,7 +50,7 @@ public class OneElementNary<T> extends NarySupport<T> {
   @Override
   public Nary<T> concat(Optional<? extends T> other) {
     if(other.isPresent()){
-      return concat(Nary.create(other));
+      return concat(Nary.from(other));
     }
     return this;
   }

--- a/src/main/java/ar/com/kfgodel/nary/impl/OneElementNary.java
+++ b/src/main/java/ar/com/kfgodel/nary/impl/OneElementNary.java
@@ -334,7 +334,7 @@ public class OneElementNary<T> extends NarySupport<T> {
   @Override
   public <U> Nary<U> mapFilteringNullResult(Function<? super T, ? extends U> mapper) {
     U mapped = mapper.apply(element);
-    return Nary.ofNullable(mapped);
+    return Nary.of(mapped);
   }
 
   @Override

--- a/src/main/java/ar/com/kfgodel/nary/impl/StreamBasedNary.java
+++ b/src/main/java/ar/com/kfgodel/nary/impl/StreamBasedNary.java
@@ -64,7 +64,7 @@ public class StreamBasedNary<T> extends NarySupport<T>  {
     if(iterator.hasNext()){
       throw new MoreThanOneElementException("Expecting 1 element in the stream to create an optional but found at least 2: " + Arrays.asList(onlyElement, iterator.next()));
     }
-    return Nary.ofNullable(onlyElement);
+    return Nary.of(onlyElement);
   }
 
   @Override

--- a/src/test/java/ar/com/kfgodel/nary/EmptyNaryTest.java
+++ b/src/test/java/ar/com/kfgodel/nary/EmptyNaryTest.java
@@ -71,13 +71,13 @@ public class EmptyNaryTest extends JavaSpec<NaryTestContext> {
           assertThat(result).isEqualTo(Lists.newArrayList());
         });
         it("returns an empty stream when #flatMap() is called",()->{
-          List<Integer> result = context().nary().flatMap((value) -> Nary.of(value))
+          List<Integer> result = context().nary().flatMap((value) -> Nary.ofNonNullable(value))
             .collectToList();
 
           assertThat(result).isEqualTo(Lists.newArrayList());
         });
         it("always returns an empty optional when called to #flatmapOptional()",()->{
-          Nary<Integer> result = context().nary().flatMapOptional((value)-> Nary.of(value).asOptional());
+          Nary<Integer> result = context().nary().flatMapOptional((value)-> Nary.ofNonNullable(value).asOptional());
 
           assertThat(result.isAbsent()).isTrue();
         });
@@ -115,7 +115,7 @@ public class EmptyNaryTest extends JavaSpec<NaryTestContext> {
             assertThat(result).isTrue();
           }); 
           it("is false if a non empty optional is passed",()->{
-            boolean result = context().nary().equals(Nary.of(1));
+            boolean result = context().nary().equals(Nary.ofNonNullable(1));
             assertThat(result).isFalse();
           });   
         });
@@ -143,7 +143,7 @@ public class EmptyNaryTest extends JavaSpec<NaryTestContext> {
             assertThat(result).isEqualTo(Lists.newArrayList());
           });
           it("returns a nary with the stream elements if the stream is not empty",()->{
-            List<Integer> result = context().nary().concat(Nary.of(1, 2, 3))
+            List<Integer> result = context().nary().concat(Nary.ofNonNullable(1, 2, 3))
               .collect(Collectors.toList());
             assertThat(result).isEqualTo(Lists.newArrayList(1, 2, 3));
           });

--- a/src/test/java/ar/com/kfgodel/nary/EmptyStreamTest.java
+++ b/src/test/java/ar/com/kfgodel/nary/EmptyStreamTest.java
@@ -56,7 +56,7 @@ public class EmptyStreamTest extends JavaSpec<NaryTestContext> {
         assertThat(result).isEqualTo(0);
       });
       it("returns an empty stream when #flatMap() is called",()->{
-        List<Integer> result = context().stream().flatMap((value) -> Nary.of(value))
+        List<Integer> result = context().stream().flatMap((value) -> Nary.ofNonNullable(value))
           .collect(Collectors.toList());
 
         assertThat(result).isEqualTo(Lists.newArrayList());

--- a/src/test/java/ar/com/kfgodel/nary/NaryCreationTest.java
+++ b/src/test/java/ar/com/kfgodel/nary/NaryCreationTest.java
@@ -7,6 +7,7 @@ import org.assertj.core.util.Lists;
 import org.junit.runner.RunWith;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Dictionary;
 import java.util.Hashtable;
 import java.util.LinkedHashMap;
@@ -42,11 +43,16 @@ public class NaryCreationTest extends JavaSpec<NaryTestContext> {
         assertThat(list).isEqualTo(Lists.newArrayList(1));
       });
 
-      it("can be donde from variable elements", () -> {
+      it("can be done from variable elements", () -> {
         Nary<Integer> nary = Nary.ofNonNullable(1, 2, 3);
 
         List<Integer> list = nary.collect(Collectors.toList());
         assertThat(list).isEqualTo(Lists.newArrayList(1, 2, 3));
+      });
+
+      it("can be created from a nullable element", () -> {
+        assertThat((Stream) Nary.of(null)).isEmpty();
+        assertThat((Stream) Nary.of(1)).isNotEmpty();
       });
 
       it("can be done from a stream", () -> {
@@ -61,13 +67,6 @@ public class NaryCreationTest extends JavaSpec<NaryTestContext> {
 
         List<Integer> list = nary.collect(Collectors.toList());
         assertThat(list).isEqualTo(Lists.newArrayList(1));
-      });
-
-      it("can be made from a nullable element as optional", () -> {
-        Nary<Integer> nary = Nary.of(null);
-
-        List<Integer> list = nary.collect(Collectors.toList());
-        assertThat(list).isEqualTo(Lists.newArrayList());
       });
 
       it("can be done from a spliterator", () -> {
@@ -86,7 +85,13 @@ public class NaryCreationTest extends JavaSpec<NaryTestContext> {
       });
 
       it("can be done from an iterable", () -> {
-        Nary<Integer> nary = Nary.from(Lists.newArrayList(1, 2, 3));
+        Nary<Integer> nary = Nary.from((Iterable)Lists.newArrayList(1, 2, 3));
+
+        List<Integer> list = nary.collect(Collectors.toList());
+        assertThat(list).isEqualTo(Lists.newArrayList(1, 2, 3));
+      });
+      it("can be done from a collection", () -> {
+        Nary<Integer> nary = Nary.from((Collection)Lists.newArrayList(1, 2, 3));
 
         List<Integer> list = nary.collect(Collectors.toList());
         assertThat(list).isEqualTo(Lists.newArrayList(1, 2, 3));
@@ -99,9 +104,9 @@ public class NaryCreationTest extends JavaSpec<NaryTestContext> {
         assertThat(list).isEqualTo(Lists.newArrayList(1, 2, 3));
       });
 
-      it("can be created from enumeration",()->{
+      it("can be created from enumeration", () -> {
         final Dictionary<String, String> dictionary = new Hashtable<>();
-        dictionary.put("text","123");
+        dictionary.put("text", "123");
 
         final List<String> elements = Nary.from(dictionary.keys())
           .collectToList();

--- a/src/test/java/ar/com/kfgodel/nary/NaryCreationTest.java
+++ b/src/test/java/ar/com/kfgodel/nary/NaryCreationTest.java
@@ -7,6 +7,8 @@ import org.assertj.core.util.Lists;
 import org.junit.runner.RunWith;
 
 import java.util.ArrayList;
+import java.util.Dictionary;
+import java.util.Hashtable;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Optional;
@@ -95,6 +97,16 @@ public class NaryCreationTest extends JavaSpec<NaryTestContext> {
 
         List<Integer> list = nary.collect(Collectors.toList());
         assertThat(list).isEqualTo(Lists.newArrayList(1, 2, 3));
+      });
+
+      it("can be created from enumeration",()->{
+        final Dictionary<String, String> dictionary = new Hashtable<>();
+        dictionary.put("text","123");
+
+        final List<String> elements = Nary.from(dictionary.keys())
+          .collectToList();
+
+        assertThat(elements).containsExactly("text");
       });
 
       it("can be created from a map", () -> {

--- a/src/test/java/ar/com/kfgodel/nary/NaryCreationTest.java
+++ b/src/test/java/ar/com/kfgodel/nary/NaryCreationTest.java
@@ -7,6 +7,7 @@ import org.assertj.core.util.Lists;
 import org.junit.runner.RunWith;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Optional;
 import java.util.Spliterators;
@@ -25,56 +26,56 @@ public class NaryCreationTest extends JavaSpec<NaryTestContext> {
   public void define() {
     describe("a nary creation", () -> {
 
-      it("can be done without elements",()->{
+      it("can be done without elements", () -> {
         Nary<Integer> nary = Nary.empty();
 
         List<Integer> list = nary.collect(Collectors.toList());
         assertThat(list).isEqualTo(Lists.newArrayList());
-      });   
-      
-      it("can be done from a single element",()->{
+      });
+
+      it("can be done from a single element", () -> {
         Nary<Integer> nary = Nary.ofNonNullable(1);
 
         List<Integer> list = nary.collect(Collectors.toList());
         assertThat(list).isEqualTo(Lists.newArrayList(1));
       });
 
-      it("can be donde from variable elements",()->{
+      it("can be donde from variable elements", () -> {
         Nary<Integer> nary = Nary.ofNonNullable(1, 2, 3);
 
         List<Integer> list = nary.collect(Collectors.toList());
         assertThat(list).isEqualTo(Lists.newArrayList(1, 2, 3));
       });
 
-      it("can be done from a stream",()->{
+      it("can be done from a stream", () -> {
         Nary<Integer> nary = Nary.from(Stream.of(1, 2, 3));
 
         List<Integer> list = nary.collect(Collectors.toList());
         assertThat(list).isEqualTo(Lists.newArrayList(1, 2, 3));
       });
 
-      it("can be done from an optional",()->{
+      it("can be done from an optional", () -> {
         Nary<Integer> nary = Nary.from(Optional.of(1));
 
         List<Integer> list = nary.collect(Collectors.toList());
         assertThat(list).isEqualTo(Lists.newArrayList(1));
       });
 
-      it("can be made from a nullable element as optional",()->{
+      it("can be made from a nullable element as optional", () -> {
         Nary<Integer> nary = Nary.of(null);
 
         List<Integer> list = nary.collect(Collectors.toList());
         assertThat(list).isEqualTo(Lists.newArrayList());
       });
 
-      it("can be done from a spliterator",()->{
+      it("can be done from a spliterator", () -> {
         Nary<Integer> nary = Nary.from(Spliterators.spliterator(new int[]{1, 2, 3}, 0));
 
         List<Integer> list = nary.collect(Collectors.toList());
         assertThat(list).isEqualTo(Lists.newArrayList(1, 2, 3));
       });
 
-      it("can be done from an iterator",()->{
+      it("can be done from an iterator", () -> {
         ArrayList<Integer> originalList = Lists.newArrayList(1, 2, 3);
         Nary<Integer> nary = Nary.from(originalList.iterator());
 
@@ -82,18 +83,29 @@ public class NaryCreationTest extends JavaSpec<NaryTestContext> {
         assertThat(list).isEqualTo(originalList);
       });
 
-      it("can be done from an iterable",()->{
+      it("can be done from an iterable", () -> {
         Nary<Integer> nary = Nary.from(Lists.newArrayList(1, 2, 3));
 
         List<Integer> list = nary.collect(Collectors.toList());
         assertThat(list).isEqualTo(Lists.newArrayList(1, 2, 3));
       });
 
-      it("can be made from an array",()->{
+      it("can be made from an array", () -> {
         Nary<Integer> nary = Nary.from(new Integer[]{1, 2, 3});
 
         List<Integer> list = nary.collect(Collectors.toList());
         assertThat(list).isEqualTo(Lists.newArrayList(1, 2, 3));
+      });
+
+      it("can be created from a map", () -> {
+        final LinkedHashMap<String, String> map = new LinkedHashMap<>();
+        map.put("text", "123");
+
+        final List<String> elements = Nary.from(map)
+          .map(entry -> entry.getKey() + entry.getValue())
+          .collectToList();
+
+        assertThat(elements).containsExactly("text123");
       });
 
     });

--- a/src/test/java/ar/com/kfgodel/nary/NaryCreationTest.java
+++ b/src/test/java/ar/com/kfgodel/nary/NaryCreationTest.java
@@ -61,7 +61,7 @@ public class NaryCreationTest extends JavaSpec<NaryTestContext> {
       });
 
       it("can be made from a nullable element as optional",()->{
-        Nary<Integer> nary = Nary.ofNullable(null);
+        Nary<Integer> nary = Nary.of(null);
 
         List<Integer> list = nary.collect(Collectors.toList());
         assertThat(list).isEqualTo(Lists.newArrayList());

--- a/src/test/java/ar/com/kfgodel/nary/NaryCreationTest.java
+++ b/src/test/java/ar/com/kfgodel/nary/NaryCreationTest.java
@@ -33,28 +33,28 @@ public class NaryCreationTest extends JavaSpec<NaryTestContext> {
       });   
       
       it("can be done from a single element",()->{
-        Nary<Integer> nary = Nary.of(1);
+        Nary<Integer> nary = Nary.ofNonNullable(1);
 
         List<Integer> list = nary.collect(Collectors.toList());
         assertThat(list).isEqualTo(Lists.newArrayList(1));
       });
 
       it("can be donde from variable elements",()->{
-        Nary<Integer> nary = Nary.of(1, 2, 3);
+        Nary<Integer> nary = Nary.ofNonNullable(1, 2, 3);
 
         List<Integer> list = nary.collect(Collectors.toList());
         assertThat(list).isEqualTo(Lists.newArrayList(1, 2, 3));
       });
 
       it("can be done from a stream",()->{
-        Nary<Integer> nary = Nary.create(Stream.of(1, 2, 3));
+        Nary<Integer> nary = Nary.from(Stream.of(1, 2, 3));
 
         List<Integer> list = nary.collect(Collectors.toList());
         assertThat(list).isEqualTo(Lists.newArrayList(1, 2, 3));
       });
 
       it("can be done from an optional",()->{
-        Nary<Integer> nary = Nary.create(Optional.of(1));
+        Nary<Integer> nary = Nary.from(Optional.of(1));
 
         List<Integer> list = nary.collect(Collectors.toList());
         assertThat(list).isEqualTo(Lists.newArrayList(1));
@@ -68,7 +68,7 @@ public class NaryCreationTest extends JavaSpec<NaryTestContext> {
       });
 
       it("can be done from a spliterator",()->{
-        Nary<Integer> nary = Nary.create(Spliterators.spliterator(new int[]{1, 2, 3}, 0));
+        Nary<Integer> nary = Nary.from(Spliterators.spliterator(new int[]{1, 2, 3}, 0));
 
         List<Integer> list = nary.collect(Collectors.toList());
         assertThat(list).isEqualTo(Lists.newArrayList(1, 2, 3));
@@ -76,21 +76,21 @@ public class NaryCreationTest extends JavaSpec<NaryTestContext> {
 
       it("can be done from an iterator",()->{
         ArrayList<Integer> originalList = Lists.newArrayList(1, 2, 3);
-        Nary<Integer> nary = Nary.create(originalList.iterator());
+        Nary<Integer> nary = Nary.from(originalList.iterator());
 
         List<Integer> list = nary.collect(Collectors.toList());
         assertThat(list).isEqualTo(originalList);
       });
 
       it("can be done from an iterable",()->{
-        Nary<Integer> nary = Nary.create(Lists.newArrayList(1, 2, 3));
+        Nary<Integer> nary = Nary.from(Lists.newArrayList(1, 2, 3));
 
         List<Integer> list = nary.collect(Collectors.toList());
         assertThat(list).isEqualTo(Lists.newArrayList(1, 2, 3));
       });
 
       it("can be made from an array",()->{
-        Nary<Integer> nary = Nary.create(new Integer[]{1, 2, 3});
+        Nary<Integer> nary = Nary.from(new Integer[]{1, 2, 3});
 
         List<Integer> list = nary.collect(Collectors.toList());
         assertThat(list).isEqualTo(Lists.newArrayList(1, 2, 3));

--- a/src/test/java/ar/com/kfgodel/nary/NaryFromOptionalTest.java
+++ b/src/test/java/ar/com/kfgodel/nary/NaryFromOptionalTest.java
@@ -32,11 +32,11 @@ public class NaryFromOptionalTest extends JavaSpec<NaryTestContext> {
     describe("an optional based nary", () -> {
 
       it("behaves like an empty nary when the optional is empty",()->{
-        Nary<Object> nary = Nary.create(Optional.empty());
+        Nary<Object> nary = Nary.from(Optional.empty());
         assertThat((Stream)nary).isSameAs(Nary.empty());
       });
 
-      context().nary(()-> Nary.create(Optional.of(3)));
+      context().nary(()-> Nary.from(Optional.of(3)));
 
       describe("as non empty optional", () -> {
         it("returns the value when get() is called",()->{
@@ -95,11 +95,11 @@ public class NaryFromOptionalTest extends JavaSpec<NaryTestContext> {
         });
         describe("#equals", () -> {
           it("is true if other optional has the same value",()->{
-            boolean result = context().nary().equals(Nary.of(3));
+            boolean result = context().nary().equals(Nary.ofNonNullable(3));
             assertThat(result).isTrue();
           });
           it("is false if the other optional has different value",()->{
-            boolean result = context().nary().equals(Nary.of(1));
+            boolean result = context().nary().equals(Nary.ofNonNullable(1));
             assertThat(result).isFalse();
           });
           it("is false if the other optional is empty",()->{
@@ -131,7 +131,7 @@ public class NaryFromOptionalTest extends JavaSpec<NaryTestContext> {
             assertThat(result).isEqualTo(Lists.newArrayList(3));
           });
           it("returns a nary with the value and the stream elements if the stream is not empty",()->{
-            List<Integer> result = context().nary().concat(Nary.of(1,2, 3))
+            List<Integer> result = context().nary().concat(Nary.ofNonNullable(1,2, 3))
               .collect(Collectors.toList());
             assertThat(result).isEqualTo(Lists.newArrayList(3, 1, 2, 3));
           });
@@ -204,7 +204,7 @@ public class NaryFromOptionalTest extends JavaSpec<NaryTestContext> {
           assertThat(result).isEqualTo(Lists.newArrayList(7.0));
         });
         it("transforms the value when #flatMap() is called",()->{
-          List<Integer> result = context().nary().flatMap((value) -> Nary.of(8))
+          List<Integer> result = context().nary().flatMap((value) -> Nary.ofNonNullable(8))
             .collect(Collectors.toList());
 
           assertThat(result).isEqualTo(Lists.newArrayList(8));
@@ -374,19 +374,19 @@ public class NaryFromOptionalTest extends JavaSpec<NaryTestContext> {
 
         it("returns itself when #findFirstNary() is called",()->{
           Nary<Integer> result = context().nary().findFirstNary();
-          assertThat((Object)result).isEqualTo(Nary.of(3));
+          assertThat((Object)result).isEqualTo(Nary.ofNonNullable(3));
         });
         it("returns itself when #findAnyNary() is called",()->{
           Nary<Integer> result = context().nary().findAnyNary();
-          assertThat((Object)result).isEqualTo(Nary.of(3));
+          assertThat((Object)result).isEqualTo(Nary.ofNonNullable(3));
         });
         it("returns itself when #minNary() is called",()->{
           Nary<Integer> result = context().nary().minNary(Integer::compareTo);
-          assertThat((Object)result).isEqualTo(Nary.of(3));
+          assertThat((Object)result).isEqualTo(Nary.ofNonNullable(3));
         });
         it("returns itself when #maxNary() is called",()->{
           Nary<Integer> result = context().nary().maxNary(Integer::compareTo);
-          assertThat((Object)result).isEqualTo(Nary.of(3));
+          assertThat((Object)result).isEqualTo(Nary.ofNonNullable(3));
         });
 
       });

--- a/src/test/java/ar/com/kfgodel/nary/NaryFromStreamTest.java
+++ b/src/test/java/ar/com/kfgodel/nary/NaryFromStreamTest.java
@@ -33,15 +33,15 @@ public class NaryFromStreamTest extends JavaSpec<NaryTestContext> {
     describe("a stream based nary", () -> {
 
       it("behaves like an empty nary when the stream is empty",()->{
-        Nary<Object> nary = Nary.create(Stream.empty());
+        Nary<Object> nary = Nary.from(Stream.empty());
         assertThat((Object)nary).isEqualTo(Nary.empty());
       });
 
       describe("when having exactly 1 element", () -> {
-        context().nary(()-> Nary.create(Stream.of(3)));
+        context().nary(()-> Nary.from(Stream.of(3)));
 
         it("behaves like an optional based nary",()->{
-          assertThat((Object)context().nary()).isEqualTo(Nary.create(Optional.of(3)));
+          assertThat((Object)context().nary()).isEqualTo(Nary.from(Optional.of(3)));
         });
 
         describe("as non empty optional", () -> {
@@ -101,11 +101,11 @@ public class NaryFromStreamTest extends JavaSpec<NaryTestContext> {
           });
           describe("#equals", () -> {
             it("is true if other optional has the same value",()->{
-              boolean result = context().nary().equals(Nary.of(3));
+              boolean result = context().nary().equals(Nary.ofNonNullable(3));
               assertThat(result).isTrue();
             });
             it("is false if the other optional has different value",()->{
-              boolean result = context().nary().equals(Nary.of(1));
+              boolean result = context().nary().equals(Nary.ofNonNullable(1));
               assertThat(result).isFalse();
             });
             it("is false if the other optional is empty",()->{
@@ -134,7 +134,7 @@ public class NaryFromStreamTest extends JavaSpec<NaryTestContext> {
               assertThat(result).isEqualTo(Lists.newArrayList(3));
             });
             it("returns a nary with the value and the stream elements if the stream is not empty",()->{
-              List<Integer> result = context().nary().concat(Nary.of(1,2, 3))
+              List<Integer> result = context().nary().concat(Nary.ofNonNullable(1,2, 3))
                 .collect(Collectors.toList());
               assertThat(result).isEqualTo(Lists.newArrayList(3, 1, 2, 3));
             });
@@ -178,7 +178,7 @@ public class NaryFromStreamTest extends JavaSpec<NaryTestContext> {
       });
 
       describe("when having more than one element", () -> {
-        context().nary(()-> Nary.create(Stream.of(3,2,1,3)));
+        context().nary(()-> Nary.from(Stream.of(3,2,1,3)));
 
         describe("as overflowed optional", () -> {
           it("throws an exception when get() is called",()->{
@@ -263,15 +263,15 @@ public class NaryFromStreamTest extends JavaSpec<NaryTestContext> {
           });
           describe("#equals", () -> {
             it("is true if other stream has the same values and order",()->{
-              boolean result = context().nary().equals(Nary.of(3, 2, 1, 3));
+              boolean result = context().nary().equals(Nary.ofNonNullable(3, 2, 1, 3));
               assertThat(result).isTrue();
             });
             it("is false if the other stream has different values",()->{
-              boolean result = context().nary().equals(Nary.of(4, 5));
+              boolean result = context().nary().equals(Nary.ofNonNullable(4, 5));
               assertThat(result).isFalse();
             });
             it("is false if the other stream has different order",()->{
-              boolean result = context().nary().equals(Nary.of(1, 2, 3, 3));
+              boolean result = context().nary().equals(Nary.ofNonNullable(1, 2, 3, 3));
               assertThat(result).isFalse();
             });
             it("is false if the other optional is empty",()->{
@@ -310,7 +310,7 @@ public class NaryFromStreamTest extends JavaSpec<NaryTestContext> {
               assertThat(result).isEqualTo(Lists.newArrayList(3, 2, 1, 3));
             });
             it("returns a nary with concatenated elements if the stream is not empty",()->{
-              List<Integer> result = context().nary().concat(Nary.of(4, 5, 6))
+              List<Integer> result = context().nary().concat(Nary.ofNonNullable(4, 5, 6))
                 .collect(Collectors.toList());
               assertThat(result).isEqualTo(Lists.newArrayList(3, 2, 1, 3, 4, 5, 6));
             });
@@ -391,7 +391,7 @@ public class NaryFromStreamTest extends JavaSpec<NaryTestContext> {
             assertThat(result).isEqualTo(Lists.newArrayList(7.0, 6.0, 5.0, 7.0));
           });
           it("transforms the values when #flatMap() is called",()->{
-            List<Integer> result = context().nary().flatMap((value) -> Nary.of(8))
+            List<Integer> result = context().nary().flatMap((value) -> Nary.ofNonNullable(8))
               .collect(Collectors.toList());
 
             assertThat(result).isEqualTo(Lists.newArrayList(8, 8, 8, 8));
@@ -549,19 +549,19 @@ public class NaryFromStreamTest extends JavaSpec<NaryTestContext> {
           });
           it("honors the contract when #findFirst() is called",()->{
             Nary<Integer> result = context().nary().findFirstNary();
-            assertThat((Object)result).isEqualTo(Nary.of(3));
+            assertThat((Object)result).isEqualTo(Nary.ofNonNullable(3));
           });
           it("honors the contract when #findAny() is called",()->{
             Nary<Integer> result = context().nary().findAnyNary();
-            assertThat((Object)result).isEqualTo(Nary.of(3));
+            assertThat((Object)result).isEqualTo(Nary.ofNonNullable(3));
           });
           it("honors the contract when #minNary() is called",()->{
             Nary<Integer> result = context().nary().minNary(Integer::compareTo);
-            assertThat((Object)result).isEqualTo(Nary.of(1));
+            assertThat((Object)result).isEqualTo(Nary.ofNonNullable(1));
           });
           it("honors the contract when #maxNary() is called",()->{
             Nary<Integer> result = context().nary().maxNary(Integer::compareTo);
-            assertThat((Object)result).isEqualTo(Nary.of(3));
+            assertThat((Object)result).isEqualTo(Nary.ofNonNullable(3));
           });
 
         });

--- a/src/test/java/ar/com/kfgodel/nary/bugs/NullMappingTest.java
+++ b/src/test/java/ar/com/kfgodel/nary/bugs/NullMappingTest.java
@@ -43,13 +43,13 @@ public class NullMappingTest extends JavaSpec<NaryTestContext> {
 
       describe("when using nary", () -> {
         it("takes null as valid result when #map() is used", () -> {
-          final List<Object> result = Nary.of("algo")
+          final List<Object> result = Nary.ofNonNullable("algo")
             .map(algo -> null)
             .collect(Collectors.toList());
           assertThat(result).isEqualTo(Lists.newArrayList((Object)null));
         });
         it("explicitly filters null as valid result when #mapFilteringNullResult() is used",()->{
-          final List<Object> result = Nary.of("algo")
+          final List<Object> result = Nary.ofNonNullable("algo")
             .mapFilteringNullResult(algo -> null)
             .map((nullValue)-> {
               throw new RuntimeException("This code is never executed");


### PR DESCRIPTION
Change the way Nary is created.
- Rename "create" to "from" to indicate that is an adaptation
- Make "of()" accept and ignore null